### PR TITLE
Renamed "link" in the class Hike to "gpx". (And in the Database)

### DIFF
--- a/src/main/java/at/fhv/journey/model/Hike.java
+++ b/src/main/java/at/fhv/journey/model/Hike.java
@@ -154,7 +154,7 @@ public class Hike {
         _dateCreated = dateCreated;
     }
 
-    @Column(name = "link")
+    @Column(name = "gpx")
     public String getGpxLocation() {
         return _gpxLocation;
     }


### PR DESCRIPTION
As the attribute link was renamed to gpx, it had to be fixed in the class and the database. The change requires everbody to pull this.