### PR TITLE
Fixed underline-bug in navbar

### DIFF
--- a/src/main/webapp/CSS/styles.css
+++ b/src/main/webapp/CSS/styles.css
@@ -92,6 +92,10 @@ body {
     align-items: center;
 }
 
+#navbar a {
+    text-decoration: none;
+}
+
 .links {
     color:white;
     padding: 100% 16px;


### PR DESCRIPTION
In some pages, the underline was still apparent when hovering over "CREATE" or "DISCOVER" in navbar.